### PR TITLE
feat: deleteElements replaces events deleteParagraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,12 +243,18 @@ If you are using a rich text editor, there is a chance that you are looking to p
 For such purpose, the `<stylo-editor/>` component triggers following custom events:
 
 - `addParagraphs`: triggered each time new paragraph(s) is added to the editable container
-- `deleteParagraphs`: triggered each time paragraph(s) are removed
 - `updateParagraphs`: triggered each time paragraph(s) are updated
+- `deleteElements`: triggered each time HTML elements(s) are removed
 
-Each paragraph is a direct child of the editable container.
+A paragraph is a direct child of the editable container.
 
-Unlike `addParagraphs` and `deleteParagraphs` that are triggered only if elements are such level are added or removed, `updateParagraphs` is triggered if the paragraphs themselves or any of their children (HTML elements and text nodes) are modified.
+The `addParagraphs` is triggered only if elements on such level is added or removed.
+
+Unlike previous event `updateParagraphs` and `deleteElements` are triggered if the paragraphs themselves or any of their children (HTML elements and text nodes) are modified.
+
+`updateParagraphs` provide the information about which paragraphs are updated - e.g. three children of a paragraph are updated at a time, only one event for the paragraph is emitted.
+
+However `deleteElements` emits any elements. With the current implementation of the mutation observer and without any external hint (such as an attribute to observe) it is not possible to detect which paragraphs was deleted.
 
 Changes following keyboard inputs are debounced.
 

--- a/src/index.html
+++ b/src/index.html
@@ -647,8 +647,8 @@
           // stylo.addEventListener('addParagraphs', ($event) =>
           //   console.log('addParagraphs', $event)
           // );
-          // stylo.addEventListener('deleteParagraphs', ($event) =>
-          //   console.log('deleteParagraphs', $event)
+          // stylo.addEventListener('deleteElements', ($event) =>
+          //   console.log('deleteElements', $event)
           // );
           // stylo.addEventListener('updateParagraphs', ($event) =>
           //   console.log('updateParagraphs', $event)

--- a/src/stores/config.store.ts
+++ b/src/stores/config.store.ts
@@ -39,10 +39,13 @@ export const DEFAULT_TEXT_PARAGRAPHS = ['h1', 'h2', 'h3', 'div', 'p'];
 
 export const DEFAULT_EXCLUDE_ATTRIBUTES = [
   'placeholder',
-  'data-gramm',
   'class',
   'spellcheck',
-  'contenteditable'
+  'contenteditable',
+  'data-gramm',
+  'data-gramm_id',
+  'data-gramm_editor',
+  'data-gr-id'
 ];
 
 export const DEFAULT_DONT_INJECT_HEAD_CSS = false;

--- a/src/utils/events.utils.spec.ts
+++ b/src/utils/events.utils.spec.ts
@@ -1,5 +1,5 @@
 import {MockHTMLElement} from '@stencil/core/mock-doc';
-import {emitAddParagraphs, emitDeleteParagraphs, emitUpdateParagraphs} from './events.utils';
+import {emitAddParagraphs, emitDeleteElements, emitUpdateParagraphs} from './events.utils';
 
 describe('event', () => {
   let editorRef, element, dispatchEventSpy;
@@ -36,15 +36,15 @@ describe('event', () => {
     expectDispatched({eventName: 'addParagraphs'});
   });
 
-  it('should emit deleteParagraphs', () => {
-    const removedParagraphs = [element];
+  it('should emit deleteElements', () => {
+    const removedElements = [element];
 
-    emitDeleteParagraphs({
+    emitDeleteElements({
       editorRef,
-      removedParagraphs
+      removedElements
     });
 
-    expectDispatched({eventName: 'deleteParagraphs'});
+    expectDispatched({eventName: 'deleteElements'});
   });
 
   it('should emit updateParagraphs', () => {

--- a/src/utils/events.utils.ts
+++ b/src/utils/events.utils.ts
@@ -6,13 +6,13 @@ export const emitAddParagraphs = ({
   addedParagraphs: HTMLElement[];
 }) => emit<HTMLElement[]>({editorRef, detail: addedParagraphs, message: 'addParagraphs'});
 
-export const emitDeleteParagraphs = ({
+export const emitDeleteElements = ({
   editorRef,
-  removedParagraphs
+  removedElements
 }: {
   editorRef: HTMLElement | undefined;
-  removedParagraphs: HTMLElement[];
-}) => emit<HTMLElement[]>({editorRef, detail: removedParagraphs, message: 'deleteParagraphs'});
+  removedElements: HTMLElement[];
+}) => emit<HTMLElement[]>({editorRef, detail: removedElements, message: 'deleteElements'});
 
 export const emitUpdateParagraphs = ({
   editorRef,


### PR DESCRIPTION
Right now, there is no way to properly detect if a paragraph or an element is deleted with the mutation observer.

It would be possible but only by adding an identifier to the paragraph - `<div paragraph_id />`.

Kind of think such attributes have to be handled by the user of stylo. Therefore this PR replaces `deleteParagraphs` with `deleteElements`