### PR TITLE
feat: attribute to identify paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fix
 
-- use and add an attribute `paragraph_id` (can be customized) to identify each paragraph*
+- use and add an attribute `paragraph_id` (can be customized) to identify each paragraph\*
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.0.17 (2022-04-29)
+
+### Fix
+
+- use and add an attribute `paragraph_id` (can be customized) to identify each paragraph*
+
+### Features
+
+- more Grammarly attributes to ignore
+
+* I wish there was another solution but did not manage to properly identify which DOM elements are paragraphs or not when deletion happen. The Mutation Observer API and Dom API do not provide yet enough information or customization about it.
+
 # 0.0.16 (2022-04-24)
 
 ### Style

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Each paragraph is a direct child of the editable container.
 
 Unlike `addParagraphs` and `deleteParagraphs` that are triggered only if elements are such level are added or removed, `updateParagraphs` is triggered if the paragraphs themselves or any of their children (HTML elements and text nodes) are modified.
 
+Stylo can detect changes for paragraphs and elements that are added or updated but cannot detect deletion of paragraphs without a hint. The Mutation Observer API does not provide yet enough information. To overcome this issue, Stylo set an attribute with empty value to identify what elements are paragraphs.
+
 Changes following keyboard inputs are debounced.
 
 ### Attributes

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Each paragraph is a direct child of the editable container.
 
 Unlike `addParagraphs` and `deleteParagraphs` that are triggered only if elements are such level are added or removed, `updateParagraphs` is triggered if the paragraphs themselves or any of their children (HTML elements and text nodes) are modified.
 
-Stylo can detect changes for paragraphs and elements that are added or updated but cannot detect deletion of paragraphs without a hint. The Mutation Observer API does not provide yet enough information. To overcome this issue, Stylo set an attribute with empty value to identify what elements are paragraphs.
+Stylo can detect changes for paragraphs and elements that are added or updated but cannot detect deleted paragraphs without a hint. The Mutation Observer API does not provide yet enough information. To overcome this issue, Stylo set an attribute with empty value to identify what elements are paragraphs.
 
 Changes following keyboard inputs are debounced.
 
@@ -258,13 +258,14 @@ Changes following keyboard inputs are debounced.
 
 Following attributes are ignored to prevent the observer to trigger and keep track of changes that are not made by the user on purpose:
 
+- paragraph_id: the attribute added to identify each paragraph
 - placeholder: the attribute used by Stylo to display the placeholder about the '/'
-- data-gramm: [Grammarly](https://www.grammarly.com/) flooding the DOM
 - class: only inline style is considered changes
 - spellcheck
 - contenteditable
+- data-gramm, data-gramm_id, data-gramm_editor and data-gr-id: [Grammarly](https://www.grammarly.com/) flooding the DOM
 
-The list of excluded attributes can be extended through the configuration ([src/types/config.ts](src/types/config.ts)).
+The list of excluded attributes and the `paragraph_id` hint can be customized through the configuration ([src/types/config.ts](src/types/config.ts)).
 
 ## Listener
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@papyrs/stylo",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papyrs/stylo",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Another kind of rich text editor",
   "author": "David Dal Busco",
   "license": "MIT",

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -16,6 +16,7 @@ import {TabEvents} from '../../events/tab.events';
 import {UndoRedoEvents} from '../../events/undo-redo.events';
 import configStore, {
   DEFAULT_EXCLUDE_ATTRIBUTES,
+  DEFAULT_PARAGRAPH_IDENTIFIER,
   DEFAULT_PLACEHOLDERS,
   DEFAULT_PLUGINS,
   DEFAULT_TEXT_PARAGRAPHS,
@@ -173,7 +174,7 @@ export class Editor implements ComponentInterface {
       placeholders,
       textParagraphs,
       menus,
-      excludeAttributes
+      attributes
     } = this.config;
 
     i18n.state.custom = customI18n?.custom;
@@ -193,10 +194,14 @@ export class Editor implements ComponentInterface {
     configStore.state.textParagraphs = textParagraphs || DEFAULT_TEXT_PARAGRAPHS;
 
     configStore.state.menus = menus;
-    configStore.state.excludeAttributes = [
-      ...DEFAULT_EXCLUDE_ATTRIBUTES,
-      ...(excludeAttributes || [])
-    ];
+
+    const paragraphIdentifier: string =
+      attributes?.paragraphIdentifier ?? DEFAULT_PARAGRAPH_IDENTIFIER;
+
+    configStore.state.attributes = {
+      paragraphIdentifier,
+      exclude: [...(attributes?.exclude || DEFAULT_EXCLUDE_ATTRIBUTES), paragraphIdentifier]
+    };
   }
 
   private destroy() {

--- a/src/events/data.events.ts
+++ b/src/events/data.events.ts
@@ -51,7 +51,7 @@ export class DataEvents {
     this.updateParagraphs(
       filterAttributesMutations({
         mutations,
-        excludeAttributes: configStore.state.excludeAttributes
+        excludeAttributes: configStore.state.attributes.exclude
       })
     );
   };
@@ -87,22 +87,17 @@ export class DataEvents {
       return;
     }
 
-    // Only those the target is the container are paragraphs
     const removedNodes: Node[] = mutations.reduce(
-      (acc: Node[], {removedNodes, target}: MutationRecord) => {
-        if (!target.isEqualNode(containerStore.state.ref)) {
-          return acc;
-        }
-
-        return [...acc, ...Array.from(removedNodes)];
-      },
+      (acc: Node[], {removedNodes}: MutationRecord) => [...acc, ...Array.from(removedNodes)],
       []
     );
 
-    // We remove text node, should not happen we only want elements as children of the container
     const removedParagraphs: HTMLElement[] = removedNodes
       .filter((node: Node) => !isTextNode(node))
-      .map((node: Node) => toHTMLElement(node));
+      .map((node: Node) => toHTMLElement(node))
+      .filter((element: HTMLElement | undefined | null) =>
+        element?.hasAttribute(configStore.state.attributes.paragraphIdentifier)
+      );
 
     if (removedParagraphs.length <= 0) {
       return;
@@ -126,7 +121,7 @@ export class DataEvents {
     });
     const removedNodesMutations: MutationRecord[] = findRemovedNodesParagraphs({
       mutations,
-      container: containerStore.state.ref
+      paragraphIdentifier: configStore.state.attributes.paragraphIdentifier
     });
 
     this.updateParagraphs([...addedNodesMutations, ...removedNodesMutations]);

--- a/src/events/data.events.ts
+++ b/src/events/data.events.ts
@@ -3,6 +3,7 @@ import configStore from '../stores/config.store';
 import containerStore from '../stores/container.store';
 import {emitAddParagraphs, emitDeleteParagraphs, emitUpdateParagraphs} from '../utils/events.utils';
 import {isTextNode, toHTMLElement} from '../utils/node.utils';
+import {setParagraphAttribute} from '../utils/paragraph.utils';
 import {
   filterAttributesMutations,
   findAddedNodesParagraphs,
@@ -41,8 +42,8 @@ export class DataEvents {
     this.dataObserver?.disconnect();
   }
 
-  private onTreeMutation = (mutations: MutationRecord[]) => {
-    this.addParagraphs(mutations);
+  private onTreeMutation = async (mutations: MutationRecord[]) => {
+    await this.addParagraphs(mutations);
     this.deleteParagraphs(mutations);
     this.updateAddedNodesParagraphs(mutations);
   };
@@ -61,7 +62,7 @@ export class DataEvents {
     this.debounceUpdateInput();
   };
 
-  private addParagraphs(mutations: MutationRecord[]) {
+  private async addParagraphs(mutations: MutationRecord[]) {
     if (!containerStore.state.ref) {
       return;
     }
@@ -74,6 +75,15 @@ export class DataEvents {
     if (addedParagraphs.length <= 0) {
       return;
     }
+
+    await Promise.all(
+      addedParagraphs.map((paragraph: HTMLElement) =>
+        setParagraphAttribute({
+          paragraph,
+          attributeName: configStore.state.attributes.paragraphIdentifier
+        })
+      )
+    );
 
     emitAddParagraphs({editorRef: this.editorRef, addedParagraphs});
   }

--- a/src/events/data.events.ts
+++ b/src/events/data.events.ts
@@ -97,6 +97,11 @@ export class DataEvents {
       return;
     }
 
+    const addedNodes: Node[] = mutations.reduce(
+      (acc: Node[], {addedNodes}: MutationRecord) => [...acc, ...Array.from(addedNodes)],
+      []
+    );
+
     const removedNodes: Node[] = mutations.reduce(
       (acc: Node[], {removedNodes}: MutationRecord) => [...acc, ...Array.from(removedNodes)],
       []
@@ -104,6 +109,10 @@ export class DataEvents {
 
     const removedParagraphs: HTMLElement[] = removedNodes
       .filter((node: Node) => !isTextNode(node))
+      .filter(
+        (removedNode: Node) =>
+          addedNodes.find((addedNode: Node) => addedNode.isEqualNode(removedNode)) === undefined
+      )
       .map((node: Node) => toHTMLElement(node))
       .filter((element: HTMLElement | undefined | null) =>
         element?.hasAttribute(configStore.state.attributes.paragraphIdentifier)

--- a/src/events/undo-redo.events.ts
+++ b/src/events/undo-redo.events.ts
@@ -379,7 +379,8 @@ export class UndoRedoEvents {
     // Paragraphs removed
     const removedParagraphs: RemovedParagraph[] = findRemovedParagraphs({
       mutations,
-      container: containerStore.state.ref
+      container: containerStore.state.ref,
+      paragraphIdentifier: configStore.state.attributes.paragraphIdentifier
     });
 
     const lowerIndex: number = Math.min(
@@ -421,7 +422,7 @@ export class UndoRedoEvents {
     });
     const removedNodesMutations: MutationRecord[] = findRemovedNodesParagraphs({
       mutations,
-      container: containerStore.state.ref
+      paragraphIdentifier: configStore.state.attributes.paragraphIdentifier
     });
 
     const needsUpdate: boolean = addedNodesMutations.length > 0 || removedNodesMutations.length > 0;
@@ -468,7 +469,7 @@ export class UndoRedoEvents {
     const updateParagraphs: HTMLElement[] = findUpdatedParagraphs({
       mutations: filterAttributesMutations({
         mutations,
-        excludeAttributes: configStore.state.excludeAttributes
+        excludeAttributes: configStore.state.attributes.exclude
       }),
       container: containerStore.state.ref
     });

--- a/src/index.html
+++ b/src/index.html
@@ -507,7 +507,7 @@
       <article contenteditable="true">
         <h2 paragraph_id><span style="color: rgb(255, 101, 169);">Stylo</span></h2>
         <div paragraph_id>Stylo is an open source <a href="https://en.wikipedia.org/wiki/WYSIWYG" rel="noopener noreferrer">WYSIWYG</a> interactive editor for JavaScript. Its goal is to bring great user experience and interactivity to the web, for everyone, with no dependencies. Stylo is a <a href="https://papy.rs" rel="noopener noreferrer">Papyrs</a> project.</div>
-        <hr paragparagraph_idraph />
+        <hr paragraph_id />
         <div paragraph_id>This is an <span style="font-weight: bold">&ZeroWidthSpace;alpha</span>&ZeroWidthSpace; version! ⚠️ The project is under active development and contributions on <a href="https://github.com/papyrs/stylo" rel="noopener noreferrer">GitHub</a> are most welcome.</div>
         <hr paragraph_id/>
         <h2 paragraph_id>Features</h2>
@@ -644,13 +644,13 @@
             menus: [imgMenu]
           };
 
-          stylo.addEventListener('addParagraphs', ($event) => console.log('addParagraphs', $event));
-          stylo.addEventListener('deleteParagraphs', ($event) =>
-            console.log('deleteParagraphs', $event)
-          );
-          stylo.addEventListener('updateParagraphs', ($event) =>
-            console.log('updateParagraphs', $event)
-          );
+          // stylo.addEventListener('addParagraphs', ($event) => console.log('addParagraphs', $event));
+          // stylo.addEventListener('deleteParagraphs', ($event) =>
+          //   console.log('deleteParagraphs', $event)
+          // );
+          // stylo.addEventListener('updateParagraphs', ($event) =>
+          //   console.log('updateParagraphs', $event)
+          // );
         });
 
         styloObserver.observe(stylo, {attributes: true});

--- a/src/index.html
+++ b/src/index.html
@@ -505,19 +505,19 @@
     <section class="editor">
       <!-- prettier-ignore -->
       <article contenteditable="true">
-        <h2><span style="color: rgb(255, 101, 169);">Stylo</span></h2>
-        <div>Stylo is an open source <a href="https://en.wikipedia.org/wiki/WYSIWYG" rel="noopener noreferrer">WYSIWYG</a> interactive editor for JavaScript. Its goal is to bring great user experience and interactivity to the web, for everyone, with no dependencies. Stylo is a <a href="https://papy.rs" rel="noopener noreferrer">Papyrs</a> project.</div>
-        <hr />
-        <div>This is an <span style="font-weight: bold">&ZeroWidthSpace;alpha</span>&ZeroWidthSpace; version! ⚠️ The project is under active development and contributions on <a href="https://github.com/papyrs/stylo" rel="noopener noreferrer">GitHub</a> are most welcome.</div>
-        <hr />
-        <h2>Features</h2>
-        <ul><li>Interactive design 🎯</li><li>Customizable 💪</li><li>Framework agnostic 😎</li><li>Lightweight (30kb gzipped, 0 deps) 🪶</li><li>Future Proof 🚀</li><li>Open Source (MIT license) ⭐️</li></ul>
-        <hr />
-        <div>Pro tips: trigger <span style="font-weight: bold;">bold</span> mode with "**", <span style="font-style: italic">italic</span> mode with whitespace and "_", and <mark>mark</mark> mode with whitespace and "`". 👾</div>
-        <div>&ZeroWidthSpace;</div>
-        <div>Cheers<br/>David</div>
-        <div>&ZeroWidthSpace;</div>
-        <img src="/assets/mogwai.jpg" loading="lazy" style="width: 50%;" />
+        <h2 paragraph_id><span style="color: rgb(255, 101, 169);">Stylo</span></h2>
+        <div paragraph_id>Stylo is an open source <a href="https://en.wikipedia.org/wiki/WYSIWYG" rel="noopener noreferrer">WYSIWYG</a> interactive editor for JavaScript. Its goal is to bring great user experience and interactivity to the web, for everyone, with no dependencies. Stylo is a <a href="https://papy.rs" rel="noopener noreferrer">Papyrs</a> project.</div>
+        <hr paragparagraph_idraph />
+        <div paragraph_id>This is an <span style="font-weight: bold">&ZeroWidthSpace;alpha</span>&ZeroWidthSpace; version! ⚠️ The project is under active development and contributions on <a href="https://github.com/papyrs/stylo" rel="noopener noreferrer">GitHub</a> are most welcome.</div>
+        <hr paragraph_id/>
+        <h2 paragraph_id>Features</h2>
+        <ul paragraph_id><li>Interactive design 🎯</li><li>Customizable 💪</li><li>Framework agnostic 😎</li><li>Lightweight (30kb gzipped, 0 deps) 🪶</li><li>Future Proof 🚀</li><li>Open Source (MIT license) ⭐️</li></ul>
+        <hr paragraph_id/>
+        <div paragraph_id>Pro tips: trigger <span style="font-weight: bold;">bold</span> mode with "**", <span style="font-style: italic">italic</span> mode with whitespace and "_", and <mark>mark</mark> mode with whitespace and "`". 👾</div>
+        <div paragraph_id>&ZeroWidthSpace;</div>
+        <div paragraph_id>Cheers<br/>David</div>
+        <div paragraph_id>&ZeroWidthSpace;</div>
+        <img paragraph_id src="/assets/mogwai.jpg" loading="lazy" style="width: 50%;" />
       </article>
 
       <stylo-editor> </stylo-editor>
@@ -644,15 +644,13 @@
             menus: [imgMenu]
           };
 
-          // stylo.addEventListener('addParagraphs', ($event) =>
-          //   console.log('addParagraphs', $event)
-          // );
-          // stylo.addEventListener('deleteParagraphs', ($event) =>
-          //   console.log('deleteParagraphs', $event)
-          // );
-          // stylo.addEventListener('updateParagraphs', ($event) =>
-          //   console.log('updateParagraphs', $event)
-          // );
+          stylo.addEventListener('addParagraphs', ($event) => console.log('addParagraphs', $event));
+          stylo.addEventListener('deleteParagraphs', ($event) =>
+            console.log('deleteParagraphs', $event)
+          );
+          stylo.addEventListener('updateParagraphs', ($event) =>
+            console.log('updateParagraphs', $event)
+          );
         });
 
         styloObserver.observe(stylo, {attributes: true});

--- a/src/stores/config.store.ts
+++ b/src/stores/config.store.ts
@@ -6,6 +6,7 @@ import {h3} from '../plugins/h3.plugin';
 import {hr} from '../plugins/hr.plugin';
 import {img} from '../plugins/img.plugin';
 import {ul} from '../plugins/ul.plugin';
+import {StyloConfigAttributes} from '../types/attributes';
 import {StyloMenu} from '../types/menu';
 import {DEFAULT_PALETTE} from '../types/palette';
 import {StyloPlugin} from '../types/plugin';
@@ -17,7 +18,7 @@ interface ConfigStore {
   menus: StyloMenu[] | undefined;
   placeholders: string[] | undefined;
   textParagraphs: string[] | undefined;
-  excludeAttributes: string[];
+  attributes: StyloConfigAttributes;
 }
 
 export const DEFAULT_PLUGINS: StyloPlugin[] = [h1, h2, h3, ul, img, code, hr];
@@ -48,13 +49,20 @@ export const DEFAULT_EXCLUDE_ATTRIBUTES = [
   'data-gr-id'
 ];
 
+export const DEFAULT_PARAGRAPH_IDENTIFIER: string = 'paragraph_id';
+
+const DEFAULT_ATTRIBUTES: StyloConfigAttributes = {
+  paragraphIdentifier: DEFAULT_PARAGRAPH_IDENTIFIER,
+  exclude: [...DEFAULT_EXCLUDE_ATTRIBUTES, DEFAULT_PARAGRAPH_IDENTIFIER]
+};
+
 const {state, onChange} = createStore<ConfigStore>({
   plugins: DEFAULT_PLUGINS,
   toolbar: DEFAULT_TOOLBAR,
   placeholders: DEFAULT_PLACEHOLDERS,
   textParagraphs: DEFAULT_TEXT_PARAGRAPHS,
   menus: undefined,
-  excludeAttributes: DEFAULT_EXCLUDE_ATTRIBUTES
+  attributes: DEFAULT_ATTRIBUTES
 });
 
 export default {state, onChange};

--- a/src/types/attributes.ts
+++ b/src/types/attributes.ts
@@ -1,0 +1,10 @@
+export interface StyloConfigAttributes {
+  /**
+   * An identifier that is mostly use to detect deletion of paragraphs. It identifies which elements are paragraphs, which are not.
+   */
+  paragraphIdentifier: string;
+  /**
+   *  Exclude attributes that should not be observed for changes. ParagraphIdentifier will be added to the list.
+   */
+  exclude: string[];
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,3 +1,4 @@
+import {StyloConfigAttributes} from './attributes';
 import {Languages} from './i18n';
 import {StyloMenu} from './menu';
 import {StyloPlugin} from './plugin';
@@ -21,8 +22,5 @@ export interface StyloConfig {
    * The paragraphs that accept text. In case user / browser tries to enter text withing another type of paragraphs, Stylo will first preprend the text in a new div to avoid text nodes at the root of the contenteditable container.
    */
   textParagraphs?: string[];
-  /**
-   * Exclude attributes that should not be observed for changes
-   */
-  excludeAttributes?: string[];
+  attributes?: Partial<StyloConfigAttributes>;
 }

--- a/src/utils/paragraph.utils.ts
+++ b/src/utils/paragraph.utils.ts
@@ -94,9 +94,6 @@ export const isParagraph = ({
   return parentElement?.isEqualNode(container);
 };
 
-export const isTargetContainer = ({target, container}: {target: Node; container: Node}): boolean =>
-  target.isEqualNode(container);
-
 export const focusParagraph = ({paragraph}: {paragraph: Node | undefined}) => {
   if (!isTextNode(paragraph)) {
     toHTMLElement(paragraph).focus();

--- a/src/utils/paragraph.utils.ts
+++ b/src/utils/paragraph.utils.ts
@@ -305,3 +305,23 @@ export const isParagraphCode = ({paragraph}: {paragraph: HTMLElement}): boolean 
 
 export const isParagraphList = ({paragraph}: {paragraph: HTMLElement}): boolean =>
   ['ul', 'ol', 'dl'].includes(paragraph.nodeName.toLowerCase());
+
+export const setParagraphAttribute = ({
+  paragraph,
+  attributeName
+}: {
+  paragraph: HTMLElement;
+  attributeName: string;
+}): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    const addObserver: MutationObserver = new MutationObserver((_mutations: MutationRecord[]) => {
+      addObserver.disconnect();
+
+      resolve();
+    });
+
+    addObserver.observe(paragraph, {attributes: true});
+
+    paragraph.setAttribute(attributeName, '');
+  });
+};

--- a/src/utils/paragraphs.utils.spec.ts
+++ b/src/utils/paragraphs.utils.spec.ts
@@ -22,7 +22,11 @@ describe('paragraphs utils', () => {
   const container = createDiv({depth: 1});
 
   const child1 = createDiv({depth: 2});
+  child1.setAttribute('paragraph_id', '');
+
   const child2 = createDiv({depth: 2});
+  child1.setAttribute('paragraph_id', '');
+
   const text = document.createTextNode('test');
   const leaf = createDiv({depth: 1});
 
@@ -54,7 +58,8 @@ describe('paragraphs utils', () => {
 
     const removedParagraphs = findRemovedParagraphs({
       mutations: [mutation, mutationRemoved, mutation],
-      container
+      container,
+      paragraphIdentifier: 'paragraph_id'
     });
     expect(removedParagraphs.length).toEqual(1);
   });
@@ -88,7 +93,7 @@ describe('paragraphs utils', () => {
     expect(mutations.length).toEqual(1);
   });
 
-  it('should find removed nodes', () => {
+  it.only('should find removed nodes', () => {
     const mutationParagraphs = {
       removedNodes: [child1, text, child2],
       target: container
@@ -105,10 +110,10 @@ describe('paragraphs utils', () => {
     } as unknown as MutationRecord;
 
     const mutations = findRemovedNodesParagraphs({
-      container,
+      paragraphIdentifier: 'paragraph_id',
       mutations: [mutationParagraphs, mutationNode, mutationLeaf]
     });
 
-    expect(mutations.length).toEqual(1);
+    expect(mutations.length).toEqual(2);
   });
 });

--- a/src/utils/paragraphs.utils.spec.ts
+++ b/src/utils/paragraphs.utils.spec.ts
@@ -93,7 +93,7 @@ describe('paragraphs utils', () => {
     expect(mutations.length).toEqual(1);
   });
 
-  it.only('should find removed nodes', () => {
+  it('should find removed nodes', () => {
     const mutationParagraphs = {
       removedNodes: [child1, text, child2],
       target: container


### PR DESCRIPTION
I wish there was another solution but did not manage to properly identify which DOM elements are paragraphs or not when deletion happen. The Mutation Observer API and Dom API do not provide yet enough information or customization about it.

This PR also fix delete within paragraphs which sometimes emit the events "deleteParagraph"