### PR TITLE
fix: reevaluate node depths when moving element from undo to redo queue

### DIFF
--- a/src/utils/undo-redo.utils.ts
+++ b/src/utils/undo-redo.utils.ts
@@ -9,7 +9,7 @@ import {
   UndoRedoSelection,
   UndoRedoUpdateParagraph
 } from '../types/undo-redo';
-import {findNodeAtDepths, isTextNode, toHTMLElement} from './node.utils';
+import {findNodeAtDepths, isTextNode, nodeDepths, toHTMLElement} from './node.utils';
 import {redoSelection, toUndoRedoSelection} from './undo-redo-selection.utils';
 
 export const stackUndoInput = ({
@@ -218,7 +218,7 @@ const undoRedoInput = async ({
     target: container,
     data: {
       index,
-      indexDepths,
+      indexDepths: nodeDepths({target, paragraph}),
       oldValue: previousValue,
       offset: newCaretPosition + (previousValue.length - oldValue.length)
     }


### PR DESCRIPTION
For example in 

<h2>
   <span>a\nb\n</span>
   
It had for effect to redo b on position 0


<h2>
   <span>ba\n\n</span>
   
Reevaluate the node depths when moving the element to the redo queue fixes the right index